### PR TITLE
Fix social links on homepage

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -11,11 +11,11 @@ const metadata = {
 <Layout metadata={metadata}>
   <div class="relative overflow-hidden">
     <!-- 🔵 Animated background layer -->
-    <div class="absolute inset-0 z-0 animate-gradient bg-gradient-to-r from-purple-400 via-blue-500 to-indigo-500 opacity-30 blur-2xl"
+    <div class="absolute inset-0 z-0 animate-gradient bg-gradient-to-r from-purple-400 via-blue-500 to-indigo-500 opacity-30 blur-2xl pointer-events-none"
   style="background-size: 200% 200%;"></div>
 
     <!-- 🧱 Content layer -->
-  <canvas id="particle-canvas" class="fixed inset-0 z-0 w-full h-full"></canvas>
+  <canvas id="particle-canvas" class="fixed inset-0 z-0 w-full h-full pointer-events-none"></canvas>
   
   <section class="prose dark:prose-invert max-w-3xl mx-auto my-16 px-4 text-center">
     <h1 class="text-4xl font-bold">Hi, I’m Reza 👋</h1>


### PR DESCRIPTION
## Summary
- prevent the animated background and particle canvas from intercepting mouse events on the homepage

## Testing
- `npm run check` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_b_6841c518659c832c906032dc62d939e6