### PR TITLE
Fix logos in technical skills

### DIFF
--- a/src/assets/images/logos/6sense.svg
+++ b/src/assets/images/logos/6sense.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="50" cy="50" r="45" fill="#000"/>
+  <path d="M55 15a35 35 0 1 0 0 70a18 18 0 1 1 0-36a12 12 0 1 0 0-24" fill="#fff"/>
+</svg>

--- a/src/assets/images/logos/adobe-analytics.svg
+++ b/src/assets/images/logos/adobe-analytics.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="50" cy="50" r="45" fill="#322de0"/>
+  <path d="M30 70 L50 30 L70 70 Z" fill="none" stroke="#ffffff" stroke-width="8"/>
+  <circle cx="50" cy="50" r="18" fill="none" stroke="#ffffff" stroke-width="8"/>
+</svg>

--- a/src/assets/images/logos/tableau.svg
+++ b/src/assets/images/logos/tableau.svg
@@ -1,0 +1,7 @@
+<svg viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg">
+  <rect width="24" height="24" x="52" y="0" fill="#2c5cc5"/>
+  <rect width="24" height="24" x="52" y="52" fill="#e97627"/>
+  <rect width="24" height="24" x="52" y="104" fill="#f9ba00"/>
+  <rect width="24" height="24" x="0" y="52" fill="#2c5cc5"/>
+  <rect width="24" height="24" x="104" y="52" fill="#2c5cc5"/>
+</svg>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from '~/layouts/PageLayout.astro';
+import Image from '~/components/common/Image.astro';
 
 const metadata = {
   title: 'Reza Bazargan – Data Strategist & AI Specialist',
@@ -79,7 +80,7 @@ const metadata = {
     <h3 class="font-semibold text-lg text-blue-400 mb-2">Business Intelligence</h3>
     <ul class="list-none space-y-2 text-sm text-neutral-200">
       <li class="flex items-center gap-2">
-        <img src="https://cdn.simpleicons.org/tableau" alt="Tableau logo" class="w-5 h-5" />
+        <Image src="~/assets/images/logos/tableau.svg" alt="Tableau logo" width={20} height={20} />
         Tableau
       </li>
       <li class="flex items-center gap-2">
@@ -114,11 +115,11 @@ const metadata = {
         Google Analytics
       </li>
       <li class="flex items-center gap-2">
-        <img src="https://img.icons8.com/ios-filled/50/adobe.png" alt="Adobe logo" class="w-5 h-5" />
+        <Image src="~/assets/images/logos/adobe-analytics.svg" alt="Adobe Analytics logo" width={20} height={20} />
         Adobe Analytics
       </li>
       <li class="flex items-center gap-2">
-        <img src="https://seeklogo.com/images/6/6sense-logo-7F071C92E0-seeklogo.com.png" alt="6sense logo" class="w-5 h-5" />
+        <Image src="~/assets/images/logos/6sense.svg" alt="6sense logo" width={20} height={20} />
         6sense
       </li>
       <li class="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- add custom SVG logos for Tableau, Adobe Analytics, and 6sense
- import and use the new logos on the homepage

## Testing
- `npm run check` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_b_684404beec30832c8638ea29abd386f2