### PR TITLE
[Blog] Why most analytics teams struggle to show business impact (and how to fix it)

### DIFF
--- a/src/data/post/why-most-analytics-teams-struggle-to-show-business-impact-an.md
+++ b/src/data/post/why-most-analytics-teams-struggle-to-show-business-impact-an.md
@@ -1,0 +1,60 @@
+```markdown
+---
+publishDate: 2026-06-11T08:00:00Z
+author: Reza Bazargan
+title: "Why Most Analytics Teams Struggle to Show Business Impact (and How to Fix It)"
+excerpt: "Analytics teams often deliver brilliant work that nobody acts on — here's what I learned about closing that gap during my years at Mentimeter."
+category: Data Strategy
+tags:
+  - analytics
+  - data strategy
+  - leadership
+  - product
+---
+
+A few years ago, I sat in a meeting where an analyst presented a beautiful dashboard. Clean charts, a thoughtful segmentation of users, a clear trend. People nodded. Someone said "great work." And then we moved on to the next agenda item.
+
+Nothing changed. No decision was made. No experiment was launched. The dashboard was looked at maybe twice more that quarter.
+
+This is the quiet failure mode of analytics teams, and I've seen it more times than I'd like to admit. The work is good. The people are smart. The tools are modern. And yet the business carries on as if the team didn't exist. The problem is rarely the quality of the analysis. It's the gap between insight and action.
+
+I want to talk about why that gap exists and what actually closes it, drawing mostly on my time at Mentimeter.
+
+## The trap of being a reporting service
+
+When I joined Mentimeter, analytics requests came in like support tickets. A product manager wanted to know how many users used a feature. A marketer wanted last month's signup numbers by channel. The team was busy, helpful, and completely reactive.
+
+The problem with this model is subtle. When you answer the question someone asked, you've made them slightly more informed. But you haven't changed what they do. They asked "how many people used feature X?" because they were curious, not because they had a decision riding on the answer. So the number lands, gets noted, and disappears.
+
+I started asking a different question before doing any analysis: *what will you do differently depending on what we find?* If the honest answer was "nothing," I'd gently push back. Not because the question was bad, but because it wasn't connected to a decision. That single question filtered out a surprising amount of work that would have generated no impact.
+
+## Impact lives next to decisions, not next to data
+
+The teams that show business impact aren't the ones with the best data infrastructure. They're the ones embedded close to where decisions get made.
+
+At Mentimeter, one of the most useful things we did was tie analytics to a specific, recurring decision: which features to prioritise on the roadmap. Instead of producing a general "feature usage" report, we built an analysis that estimated how much each feature contributed to users converting from free to paid. That changed the conversation entirely. Now the data wasn't interesting — it was load-bearing. Product managers argued about it, challenged the assumptions, and ultimately changed the roadmap because of it.
+
+The difference wasn't technical sophistication. The conversion analysis was simpler than many dashboards we'd built. The difference was that it sat directly underneath a decision people genuinely cared about.
+
+## Speak in the language of the receiver
+
+I've watched analysts present a model's precision and recall to a room of commercial people and wonder why eyes glazed over. The audience didn't care about recall. They cared about how many good leads they'd miss if they trusted the model.
+
+Translation is part of the job, and it's not optional. When I worked later with public sector clients here in Sweden — municipalities trying to use data to plan services — the same principle held. A region doesn't want to hear about "predictive accuracy" for elderly care demand. They want to know whether they'll have enough home-care staff in the south district next winter, and how confident they can be. Same analysis, completely different framing. The framing is what makes it usable.
+
+## Measure your own impact, honestly
+
+Here's an uncomfortable one. Most analytics teams can't tell you which decisions they actually influenced last quarter. They can tell you how many dashboards they shipped, how many queries they ran, how many tickets they closed. But that's activity, not impact.
+
+At Mentimeter we started keeping a simple log: decisions where our analysis played a real role, and roughly what the outcome was. It was rough and a bit subjective. But it forced us to confront how much of our output led nowhere — and it gave us a story to tell leadership that wasn't "we were busy." It was "we helped change these five things, and here's what happened."
+
+That log also changed how we chose what to work on. When you measure influence rather than output, you naturally drift toward the work that matters.
+
+## The fix isn't more data
+
+If I had to compress all of this into one idea, it's that impact is a relationship, not a deliverable. It comes from sitting close to decisions, asking what someone will do differently, translating into their language, and then being honest about whether anything actually changed.
+
+The teams that struggle are usually doing excellent work in isolation. The fix is rarely more data, more tools, or smarter models. It's getting closer to the moment where someone has to choose — and making sure your work is sitting right there when they do.
+
+*Reza Bazargan is a Senior Data Strategist at Governo Insikt AB, where he helps public sector organisations turn data into decisions that actually change how services are run.*
+```


### PR DESCRIPTION
## New blog post ready for review

**Title:** Why most analytics teams struggle to show business impact (and how to fix it)
**Category:** Data Strategy
**File:** `src/data/post/why-most-analytics-teams-struggle-to-show-business-impact-an.md`

---

Review the post in the `Files changed` tab. When you're happy with it, merge this PR to publish.

*Generated by the weekly blog agent.*